### PR TITLE
Return valid usage string (fixes #12)

### DIFF
--- a/intake/src/main/java/com/sk89q/intake/ImmutableDescription.java
+++ b/intake/src/main/java/com/sk89q/intake/ImmutableDescription.java
@@ -83,7 +83,7 @@ public final class ImmutableDescription implements Description {
             if (!first) {
                 builder.append(" ");
             }
-            builder.append(parameter);
+            builder.append(parameter.getName());
             first = false;
         }
         


### PR DESCRIPTION
We were just appending the parameter instead of appending the actual parameter name in the string builder. This should fix #12.