### PR TITLE
Fix an exception thrown with @Switch Integers

### DIFF
--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/NumberProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/NumberProvider.java
@@ -49,7 +49,7 @@ abstract class NumberProvider<T extends Number> implements Provider<T> {
      */
     @Nullable
     protected static Double parseNumericInput(@Nullable String input) throws ArgumentParseException {
-        if (input == null) {
+        if (input == null || input.equals("")) {
             return null;
         }
 


### PR DESCRIPTION
If the switch wasn't present in the command or didn't have a value the NumberFormatException would be thrown later in the same method
