### PR TITLE
Implement completion suggestions provided by argument providers.

### DIFF
--- a/intake-example/src/main/java/com/sk89q/intake/example/parametric/module/BodyProvider.java
+++ b/intake-example/src/main/java/com/sk89q/intake/example/parametric/module/BodyProvider.java
@@ -59,7 +59,7 @@ public class BodyProvider implements Provider<Body> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix, Namespace locals) {
+    public List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers) {
         return ImmutableList.copyOf(universe.getPrefixedWith(prefix).keySet());
     }
 }

--- a/intake-example/src/main/java/com/sk89q/intake/example/parametric/module/BodyProvider.java
+++ b/intake-example/src/main/java/com/sk89q/intake/example/parametric/module/BodyProvider.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.sk89q.intake.argument.ArgumentException;
 import com.sk89q.intake.argument.ArgumentParseException;
 import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.Namespace;
 import com.sk89q.intake.example.parametric.model.Body;
 import com.sk89q.intake.example.parametric.model.Universe;
 import com.sk89q.intake.parametric.Provider;
@@ -58,7 +59,7 @@ public class BodyProvider implements Provider<Body> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix) {
+    public List<String> getSuggestions(String prefix, Namespace locals) {
         return ImmutableList.copyOf(universe.getPrefixedWith(prefix).keySet());
     }
 }

--- a/intake-example/src/main/java/com/sk89q/intake/example/sender/SenderProvider.java
+++ b/intake-example/src/main/java/com/sk89q/intake/example/sender/SenderProvider.java
@@ -22,6 +22,7 @@ package com.sk89q.intake.example.sender;
 import com.google.common.collect.ImmutableList;
 import com.sk89q.intake.argument.ArgumentException;
 import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.Namespace;
 import com.sk89q.intake.parametric.Provider;
 import com.sk89q.intake.parametric.ProvisionException;
 
@@ -48,7 +49,7 @@ public class SenderProvider implements Provider<User> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix) {
+    public List<String> getSuggestions(String prefix, Namespace locals) {
         return ImmutableList.of();
     }
 

--- a/intake-example/src/main/java/com/sk89q/intake/example/sender/SenderProvider.java
+++ b/intake-example/src/main/java/com/sk89q/intake/example/sender/SenderProvider.java
@@ -49,7 +49,7 @@ public class SenderProvider implements Provider<User> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix, Namespace locals) {
+    public List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers) {
         return ImmutableList.of();
     }
 

--- a/intake-example/src/main/java/com/sk89q/intake/example/sender/UserProvider.java
+++ b/intake-example/src/main/java/com/sk89q/intake/example/sender/UserProvider.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.sk89q.intake.argument.ArgumentException;
 import com.sk89q.intake.argument.ArgumentParseException;
 import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.Namespace;
 import com.sk89q.intake.parametric.Provider;
 import com.sk89q.intake.parametric.ProvisionException;
 
@@ -56,7 +57,7 @@ public class UserProvider implements Provider<User> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix) {
+    public List<String> getSuggestions(String prefix, Namespace locals) {
         return ImmutableList.of();
     }
 

--- a/intake-example/src/main/java/com/sk89q/intake/example/sender/UserProvider.java
+++ b/intake-example/src/main/java/com/sk89q/intake/example/sender/UserProvider.java
@@ -57,7 +57,7 @@ public class UserProvider implements Provider<User> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix, Namespace locals) {
+    public List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers) {
         return ImmutableList.of();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/completion/CommandCompleter.java
+++ b/intake/src/main/java/com/sk89q/intake/completion/CommandCompleter.java
@@ -33,7 +33,7 @@ public interface CommandCompleter {
      * Get a list of suggestions based on input.
      *
      * @param arguments the arguments entered up to this point
-     * @param locals the locals
+     * @param locals The namespace to send to providers
      * @return a list of suggestions
      * @throws CommandException thrown if there was a parsing error
      */

--- a/intake/src/main/java/com/sk89q/intake/internal/parametric/ConstantProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/internal/parametric/ConstantProvider.java
@@ -20,6 +20,7 @@
 package com.sk89q.intake.internal.parametric;
 
 import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.Namespace;
 import com.sk89q.intake.parametric.Provider;
 
 import javax.annotation.Nullable;
@@ -47,7 +48,7 @@ class ConstantProvider<T> implements Provider<T> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix) {
+    public List<String> getSuggestions(String prefix, Namespace locals) {
         return Collections.emptyList();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/internal/parametric/ConstantProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/internal/parametric/ConstantProvider.java
@@ -48,7 +48,7 @@ class ConstantProvider<T> implements Provider<T> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix, Namespace locals) {
+    public List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers) {
         return Collections.emptyList();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/AbstractParametricCallable.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/AbstractParametricCallable.java
@@ -274,7 +274,7 @@ public abstract class AbstractParametricCallable implements CommandCallable {
 
     @Override
     public List<String> getSuggestions(String arguments, Namespace locals) throws CommandException {
-        return builder.getDefaultCompleter().getSuggestions(arguments, locals);
+        return parser.parseSuggestions(arguments, locals);
     }
 
 }

--- a/intake/src/main/java/com/sk89q/intake/parametric/ArgumentParser.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/ArgumentParser.java
@@ -145,7 +145,7 @@ public final class ArgumentParser {
 
         ParameterEntry entry = parameters.get(parameter);
 
-        return entry.getBinding().getProvider().getSuggestions(arg, locals);
+        return entry.getBinding().getProvider().getSuggestions(arg, locals, entry.getModifiers());
     }
 
     private Object getDefaultValue(ParameterEntry entry, CommandArgs arguments) {

--- a/intake/src/main/java/com/sk89q/intake/parametric/ArgumentParser.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/ArgumentParser.java
@@ -140,11 +140,11 @@ public final class ArgumentParser {
         int argId = split.length - 1;
         String arg = split[argId];
 
+        if(argId > userParams.size()) return ImmutableList.of();
         Parameter parameter = userParams.get(argId);
         if(parameter == null) return ImmutableList.of();
 
         ParameterEntry entry = parameters.get(parameter);
-
         return entry.getBinding().getProvider().getSuggestions(arg, locals, entry.getModifiers());
     }
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/Provider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/Provider.java
@@ -21,6 +21,7 @@ package com.sk89q.intake.parametric;
 
 import com.sk89q.intake.argument.ArgumentException;
 import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.Namespace;
 
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
@@ -61,8 +62,9 @@ public interface Provider<T> {
      * be returned.</p>
      *
      * @param prefix What the user has typed so far (may be an empty string)
+     * @param locals The namespace under which this command's suggestions are being provided
      * @return A list of suggestions
      */
-    List<String> getSuggestions(String prefix);
+    List<String> getSuggestions(String prefix, Namespace locals);
 
 }

--- a/intake/src/main/java/com/sk89q/intake/parametric/Provider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/Provider.java
@@ -63,8 +63,9 @@ public interface Provider<T> {
      *
      * @param prefix What the user has typed so far (may be an empty string)
      * @param locals The namespace under which this command's suggestions are being provided
+     * @param modifiers The modifiers on the parameter
      * @return A list of suggestions
      */
-    List<String> getSuggestions(String prefix, Namespace locals);
+    List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers);
 
 }

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/BooleanProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/BooleanProvider.java
@@ -45,7 +45,7 @@ class BooleanProvider implements Provider<Boolean> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix, Namespace locals) {
+    public List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers) {
         return Collections.emptyList();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/BooleanProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/BooleanProvider.java
@@ -21,6 +21,7 @@ package com.sk89q.intake.parametric.provider;
 
 import com.sk89q.intake.argument.ArgumentException;
 import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.Namespace;
 import com.sk89q.intake.parametric.Provider;
 
 import javax.annotation.Nullable;
@@ -44,7 +45,7 @@ class BooleanProvider implements Provider<Boolean> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix) {
+    public List<String> getSuggestions(String prefix, Namespace locals) {
         return Collections.emptyList();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/CommandArgsProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/CommandArgsProvider.java
@@ -50,7 +50,7 @@ class CommandArgsProvider implements Provider<CommandArgs> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix, Namespace locals) {
+    public List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers) {
         return ImmutableList.of();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/CommandArgsProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/CommandArgsProvider.java
@@ -22,6 +22,7 @@ package com.sk89q.intake.parametric.provider;
 import com.google.common.collect.ImmutableList;
 import com.sk89q.intake.argument.ArgumentException;
 import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.Namespace;
 import com.sk89q.intake.parametric.Provider;
 import com.sk89q.intake.parametric.ProvisionException;
 
@@ -49,7 +50,7 @@ class CommandArgsProvider implements Provider<CommandArgs> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix) {
+    public List<String> getSuggestions(String prefix, Namespace locals) {
         return ImmutableList.of();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/EnumProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/EnumProvider.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.sk89q.intake.argument.ArgumentException;
 import com.sk89q.intake.argument.ArgumentParseException;
 import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.Namespace;
 import com.sk89q.intake.parametric.Provider;
 import com.sk89q.intake.parametric.ProvisionException;
 
@@ -78,7 +79,7 @@ public class EnumProvider<T extends Enum<T>> implements Provider<T> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix) {
+    public List<String> getSuggestions(String prefix, Namespace locals) {
         List<String> suggestions = Lists.newArrayList();
         String test = simplify(prefix);
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/EnumProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/EnumProvider.java
@@ -79,7 +79,7 @@ public class EnumProvider<T extends Enum<T>> implements Provider<T> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix, Namespace locals) {
+    public List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers) {
         List<String> suggestions = Lists.newArrayList();
         String test = simplify(prefix);
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/NumberProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/NumberProvider.java
@@ -37,7 +37,7 @@ abstract class NumberProvider<T extends Number> implements Provider<T> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix, Namespace locals) {
+    public List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers) {
         return Collections.emptyList();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/NumberProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/NumberProvider.java
@@ -20,6 +20,7 @@
 package com.sk89q.intake.parametric.provider;
 
 import com.sk89q.intake.argument.ArgumentParseException;
+import com.sk89q.intake.argument.Namespace;
 import com.sk89q.intake.parametric.Provider;
 import com.sk89q.intake.parametric.annotation.Range;
 
@@ -36,7 +37,7 @@ abstract class NumberProvider<T extends Number> implements Provider<T> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix) {
+    public List<String> getSuggestions(String prefix, Namespace locals) {
         return Collections.emptyList();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/StringProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/StringProvider.java
@@ -49,7 +49,7 @@ class StringProvider implements Provider<String> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix, Namespace locals) {
+    public List<String> getSuggestions(String prefix, Namespace locals, List<? extends Annotation> modifiers) {
         return Collections.emptyList();
     }
 

--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/StringProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/StringProvider.java
@@ -22,6 +22,7 @@ package com.sk89q.intake.parametric.provider;
 import com.sk89q.intake.argument.ArgumentException;
 import com.sk89q.intake.argument.ArgumentParseException;
 import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.Namespace;
 import com.sk89q.intake.parametric.Provider;
 import com.sk89q.intake.parametric.annotation.Validate;
 
@@ -48,7 +49,7 @@ class StringProvider implements Provider<String> {
     }
 
     @Override
-    public List<String> getSuggestions(String prefix) {
+    public List<String> getSuggestions(String prefix, Namespace locals) {
         return Collections.emptyList();
     }
 

--- a/intake/src/test/java/com/sk89q/intake/parametric/provider/EnumProviderTest.java
+++ b/intake/src/test/java/com/sk89q/intake/parametric/provider/EnumProviderTest.java
@@ -52,13 +52,13 @@ public class EnumProviderTest {
     public void testGetSuggestions() throws Exception {
         Namespace namespace = new Namespace();
 
-        assertThat(provider.getSuggestions("", namespace), containsInAnyOrder("small", "medium", "large", "very_large"));
-        assertThat(provider.getSuggestions("s", namespace), containsInAnyOrder("small"));
-        assertThat(provider.getSuggestions("la", namespace), containsInAnyOrder("large"));
-        assertThat(provider.getSuggestions("very", namespace), containsInAnyOrder("very_large"));
-        assertThat(provider.getSuggestions("verylarg", namespace), containsInAnyOrder("very_large"));
-        assertThat(provider.getSuggestions("very_", namespace), containsInAnyOrder("very_large"));
-        assertThat(provider.getSuggestions("tiny", namespace), Matchers.<String>empty());
+        assertThat(provider.getSuggestions("", namespace, ImmutableList.<Annotation>of()), containsInAnyOrder("small", "medium", "large", "very_large"));
+        assertThat(provider.getSuggestions("s", namespace, ImmutableList.<Annotation>of()), containsInAnyOrder("small"));
+        assertThat(provider.getSuggestions("la", namespace, ImmutableList.<Annotation>of()), containsInAnyOrder("large"));
+        assertThat(provider.getSuggestions("very", namespace, ImmutableList.<Annotation>of()), containsInAnyOrder("very_large"));
+        assertThat(provider.getSuggestions("verylarg", namespace, ImmutableList.<Annotation>of()), containsInAnyOrder("very_large"));
+        assertThat(provider.getSuggestions("very_", namespace, ImmutableList.<Annotation>of()), containsInAnyOrder("very_large"));
+        assertThat(provider.getSuggestions("tiny", namespace, ImmutableList.<Annotation>of()), Matchers.<String>empty());
     }
 
     enum Size {

--- a/intake/src/test/java/com/sk89q/intake/parametric/provider/EnumProviderTest.java
+++ b/intake/src/test/java/com/sk89q/intake/parametric/provider/EnumProviderTest.java
@@ -22,6 +22,7 @@ package com.sk89q.intake.parametric.provider;
 import com.google.common.collect.ImmutableList;
 import com.sk89q.intake.argument.ArgumentParseException;
 import com.sk89q.intake.argument.Arguments;
+import com.sk89q.intake.argument.Namespace;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -49,13 +50,15 @@ public class EnumProviderTest {
 
     @Test
     public void testGetSuggestions() throws Exception {
-        assertThat(provider.getSuggestions(""), containsInAnyOrder("small", "medium", "large", "very_large"));
-        assertThat(provider.getSuggestions("s"), containsInAnyOrder("small"));
-        assertThat(provider.getSuggestions("la"), containsInAnyOrder("large"));
-        assertThat(provider.getSuggestions("very"), containsInAnyOrder("very_large"));
-        assertThat(provider.getSuggestions("verylarg"), containsInAnyOrder("very_large"));
-        assertThat(provider.getSuggestions("very_"), containsInAnyOrder("very_large"));
-        assertThat(provider.getSuggestions("tiny"), Matchers.<String>empty());
+        Namespace namespace = new Namespace();
+
+        assertThat(provider.getSuggestions("", namespace), containsInAnyOrder("small", "medium", "large", "very_large"));
+        assertThat(provider.getSuggestions("s", namespace), containsInAnyOrder("small"));
+        assertThat(provider.getSuggestions("la", namespace), containsInAnyOrder("large"));
+        assertThat(provider.getSuggestions("very", namespace), containsInAnyOrder("very_large"));
+        assertThat(provider.getSuggestions("verylarg", namespace), containsInAnyOrder("very_large"));
+        assertThat(provider.getSuggestions("very_", namespace), containsInAnyOrder("very_large"));
+        assertThat(provider.getSuggestions("tiny", namespace), Matchers.<String>empty());
     }
 
     enum Size {


### PR DESCRIPTION
This commit implements argument-level command completion suggestions by using the providers for the given arguments, meaning that no extra special suggestion methods on the command classes are necessary.

Note: This commit breaks any current implementation of the Provider class, because the method signature for the getSuggestions method has changed (one argument was added), but that shouldn't be too big of a deal. Some refactoring and you should be up and running again.

Note 2: This is not a tidy solution. Instead of storing parameters as a list, in the ArgumentParser class, I had to change it to a LinkedHashMap to not only be able to get the user provided arguments and their ParameterEntry objects directly (for performance reasons), but also because we need to store the order in which elements are added to that map. If someone has a better alternative, be my guest!

Note 3: The actual code to make this work is very small, most of the changes are just to "unbreak" the code because of the method signature change I talked about earlier.

Note 4: Code compiles and has been tested.

Edit:
You might ask, why another PR to implement argument completions? Well, because all other PRs I've seen were using custom completers on the Command classes. That's pretty useless considering providers already have a system for dealing with this. So, what I've done is, instead of creating a whole array of new classes to achieve this goal, I've just taken the existing system and expanded it to support suggestions properly. This should make it really easy to implement suggestions in existing projects you might have, plus, prevents code duplication and promotes organization by placing code about the same thing in the same class.
