### PR TITLE
Simplify TextProvider, Fix all @text ending with space

### DIFF
--- a/intake/src/main/java/com/sk89q/intake/parametric/provider/TextProvider.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/provider/TextProvider.java
@@ -20,7 +20,6 @@
 package com.sk89q.intake.parametric.provider;
 
 import com.sk89q.intake.argument.ArgumentException;
-import com.sk89q.intake.argument.MissingArgumentException;
 import com.sk89q.intake.argument.CommandArgs;
 
 import javax.annotation.Nullable;
@@ -34,25 +33,13 @@ class TextProvider extends StringProvider {
     @Nullable
     @Override
     public String get(CommandArgs arguments, List<? extends Annotation> modifiers) throws ArgumentException {
-        StringBuilder builder = new StringBuilder();
-        boolean first = true;
-        while (true) {
-            if (!first) {
-                builder.append(" ");
-            }
-            try {
-                builder.append(arguments.next());
-            } catch (MissingArgumentException ignored) {
-                break;
-            }
-            first = false;
+        StringBuilder builder = new StringBuilder(arguments.next()); //throws an exception if there's no first arg
+        while (arguments.hasNext()) {
+            builder.append(" ").append(arguments.next());
         }
-        if (first) {
-            throw new MissingArgumentException();
-        }
-        String v = builder.toString();
-        validate(v, modifiers);
-        return v;
+        String text = builder.toString();
+        validate(text, modifiers);
+        return text;
     }
 
 }

--- a/intake/src/test/java/com/sk89q/intake/parametric/provider/TextProviderTest.java
+++ b/intake/src/test/java/com/sk89q/intake/parametric/provider/TextProviderTest.java
@@ -1,0 +1,120 @@
+/*
+ * Intake, a command processing library
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) Intake team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+package com.sk89q.intake.parametric.provider;
+
+import com.google.common.collect.ImmutableList;
+import com.sk89q.intake.argument.Arguments;
+import com.sk89q.intake.argument.CommandArgs;
+import com.sk89q.intake.argument.CommandContext;
+import com.sk89q.intake.argument.MissingArgumentException;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests the text provider shipped with Intake for correct behaviour.
+ */
+public class TextProviderTest {
+    @Test
+    public void testGetWithArgString() throws Exception {
+        //given
+        TextProvider provider = new TextProvider();
+        String inputText = "some text";
+        CommandArgs arguments = givenArgumentsFromText(inputText);
+        //when
+        String result = provider.get(arguments, ImmutableList.<Annotation>of());
+        //then
+        assertThat("result must be the input text exactly", result, is(inputText));
+    }
+
+    @Test
+    public void testGetWithArgStringAndSpaceAtEnd() throws Exception {
+        //given
+        TextProvider provider = new TextProvider();
+        String inputText = "some text ";
+        CommandArgs arguments = givenArgumentsFromText(inputText);
+        //when
+        String result = provider.get(arguments, ImmutableList.<Annotation>of());
+        //then
+        assertThat("result must be the input text, with the trailing space", result, is("some text "));
+    }
+
+    @Test
+    public void testGetWithEmptyArgString() throws Exception {
+        //given
+        TextProvider provider = new TextProvider();
+        String inputText = "";
+        CommandArgs arguments = givenArgumentsFromText(inputText);
+        //when
+        String result = provider.get(arguments, ImmutableList.<Annotation>of());
+        //then
+        assertThat("result must be an empty string", result, is(inputText));
+    }
+
+    @Test
+    public void testGetWithSpaceArgString() throws Exception {
+        //given
+        TextProvider provider = new TextProvider();
+        String inputText = " ";
+        CommandArgs arguments = givenArgumentsFromText(inputText);
+        //when
+        String result = provider.get(arguments, ImmutableList.<Annotation>of());
+        //then
+        assertThat("result must be a space", result, is(inputText));
+    }
+
+    @Test(expected = MissingArgumentException.class)
+    public void testGetWithOtherConsumedArgs() throws Exception {
+        //given
+        TextProvider provider = new TextProvider();
+        String inputText = "before text";
+        CommandArgs arguments = givenArgumentsFromText(inputText);
+        Assume.assumeThat("first consumed arg is correct", arguments.next(), is("before"));
+        Assume.assumeThat("second consumed arg is correct", arguments.next(), is("text"));
+        //when
+        provider.get(arguments, ImmutableList.<Annotation>of());
+        //then a MissingArgumentException is thrown
+    }
+
+    @Test
+    public void testGetWithOtherConsumedArgsAndSpace() throws Exception {
+        //given
+        TextProvider provider = new TextProvider();
+        String inputText = "before text ";
+        CommandArgs arguments = givenArgumentsFromText(inputText);
+        Assume.assumeThat("first consumed arg is correct", arguments.next(), is("before"));
+        Assume.assumeThat("second consumed arg is correct", arguments.next(), is("text"));
+        //when
+        String result = provider.get(arguments, ImmutableList.<Annotation>of());
+        //then
+        assertThat("result must be an empty string", result, is(""));
+    }
+
+    private CommandArgs givenArgumentsFromText(String inputText) {
+        String[] split = CommandContext.split(inputText);
+        return Arguments.of(split);
+    }
+
+}


### PR DESCRIPTION
This PR simplifies TextProvider to be a lot clearer and also avoid swallowing an unnecessary exception.

Furthermore, it changes its behaviour so that created text does not always have a space at the end. Usually, people don't mean to add an unnecessary space at the end of their text argument if they don't put more text.

The motivation for this commit is that I am currently experiencing the space problem in my usage of this library.

Thanks!
