### PR TITLE
Fix only single @Classifier allowed per parameter class

### DIFF
--- a/intake/src/main/java/com/sk89q/intake/parametric/Key.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/Key.java
@@ -69,11 +69,28 @@ public final class Key<T> implements Comparable<Key<?>> {
             } else if (type == null && o.type != null) {
                 return 1;
             } else {
-                return 0;
+                //allow for different classifiers in the same bindings list
+                return classifier.getName().compareTo(o.classifier.getName());
             }
         } else {
             return 0;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Key)) return false;
+        Key<?> key = (Key<?>) o;
+        if (type != null ? !type.equals(key.type) : key.type != null) return false;
+        return classifier != null ? classifier.equals(key.classifier) : key.classifier == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type != null ? type.hashCode() : 0;
+        result = 31 * result + (classifier != null ? classifier.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/intake/src/test/java/com/sk89q/intake/parametric/KeyTest.java
+++ b/intake/src/test/java/com/sk89q/intake/parametric/KeyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Intake, a command processing library
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) Intake team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.intake.parametric;
+
+import com.google.common.collect.Sets;
+import com.sk89q.intake.parametric.annotation.Classifier;
+import com.sk89q.intake.parametric.annotation.Text;
+import org.junit.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.TreeSet;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+/**
+ * Tests correct behaviour of the Key class, currently only focusing on correct collection
+ * behaviour.
+ */
+public class KeyTest {
+    @Test
+    public void testMultipleClassifiersInTreeSet() {
+        //given
+        Key<String> keyWithoutClassifier = Key.get(String.class);
+        Key<String> keyWithClassifier = Key.get(String.class, Text.class);
+        Key<String> keyWithAnotherClassifier = Key.get(String.class, MyClassifier.class);
+        TreeSet<Key<?>> keySet = Sets.newTreeSet(); //this mimics BindingsList behaviour
+        keySet.add(keyWithoutClassifier);
+        assumeThat(keySet.add(keyWithAnotherClassifier), is(true));
+        //when
+        boolean added = keySet.add(keyWithClassifier);
+        //then
+        assertThat("two keys with different classifiers must be accepted in a single set", added, is(true));
+        assertThat("other classifier must be contained in set",
+                keySet.contains(Key.get(String.class, MyClassifier.class)), is(true));
+    }
+
+    @Classifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.PARAMETER)
+    private @interface MyClassifier {
+
+    }
+}


### PR DESCRIPTION
**Current behaviour:**
Currently, it is not possible to register more than one classifier annotation (with a provider) for a single parameter type.

The cause for this is that `Key#compareTo(Key)` returned `0` (equal) for any two `Key` objects that had _any_ classifier. Therefore, `TreeSet` believes that those were the same, and refuses to add another Key with a different qualifier to a `BindingList`.

**Justification:**
This seems like odd behaviour to me. Given the bindings API with classifier support, developers could reasonably expect that they'd be able to add more than one classifier per parameter type. For that reason, this PR changes this behaviour to what I deem to be the intended behaviour.

The use case for the changed behaviour is that, as a developer, I want to be able to register different providers for a single parameter type. The classifier API suggests that this is possible, while it actually is not currently. Specifically, I tried to register a new String provider with custom behaviour, classified by a classifier annotation, but noticed that only the shipped `@Text` was recognised and mapped to the correct provider. During a debug session, I found the cause to be what is described above.

**Implementation:**
The implementation of the fix is quite simple: The `Key#compareTo(Key)` method now returns the result of `String#compareTo(String)` of the classifier class name if both keys have a classifier. This allows any `Set` to accept `Key` instances with non-null, but different classifiers. To have `Key#compareTo(Key)` consistent with `#equals(Object)`, I also added custom `#equals(Object)` and `#hashCode()` implementations. It is also generally considered good practice to implement `#equals(Object)` and `#hashCode()` if the class is to be used as Collection key.

**Verification:**
This PR also provides a unit tests for the described (presumably) correct behaviour. The test correctly fails with the previous implementation and passes with the modifications.

Thanks!
