### PR TITLE
Fixed issue with Parametric commands failing due to CommandArgs not being in namespace.

### DIFF
--- a/intake/src/main/java/com/sk89q/intake/parametric/AbstractParametricCallable.java
+++ b/intake/src/main/java/com/sk89q/intake/parametric/AbstractParametricCallable.java
@@ -165,6 +165,7 @@ public abstract class AbstractParametricCallable implements CommandCallable {
         String[] split = CommandContext.split(calledCommand + " " + stringArguments);
         CommandContext context = new CommandContext(split, parser.getValueFlags(), false, namespace);
         final CommandArgs commandArgs = Arguments.viewOf(context);
+        namespace.put(CommandArgs.class, commandArgs);
         List<InvokeHandler> handlers = new ArrayList<InvokeHandler>();
 
         // Provide help if -? is specified
@@ -203,8 +204,6 @@ public abstract class AbstractParametricCallable implements CommandCallable {
             if (!invoke) {
                 return true; // Abort early
             }
-
-            namespace.put(CommandArgs.class, commandArgs);
 
             // invoke
             try {


### PR DESCRIPTION
Currently, if you try to setup Parametric commands, it fails due to the DefaultModule expecting CommandArgs to be in the namespace when `parser.parseArguments` is called. This moves it to where it's defined, meaning it's available.